### PR TITLE
Add a `@closable` argument

### DIFF
--- a/addon/components/environment-banner.hbs
+++ b/addon/components/environment-banner.hbs
@@ -1,4 +1,4 @@
-<AuAlert @size='tiny' @skin={{if @skin @skin 'warning'}} class='au-u-margin-bottom-none'>
+<AuAlert @size='tiny' @skin={{if @skin @skin 'warning'}} class='au-u-margin-bottom-none' @closable={{@closable}}>
   <div class='au-u-flex au-u-flex--spaced au-u-flex--between'>
     <p class='au-u-flex au-u-medium au-u-1-5@medium au-u-flex--vertical-center'>
       Environment: {{@environmentName}}


### PR DESCRIPTION
The banner takes up valuable space in some apps, and testers might want to close it when testing something space sensitive on a specific environment.

It doesn't look super pretty, but it's the best we have as long as we use the `AuAlert` component underneath.