### PR TITLE
Allow users to set a message using block contents

### DIFF
--- a/addon/components/environment-banner.hbs
+++ b/addon/components/environment-banner.hbs
@@ -4,9 +4,13 @@
       Environment: {{@environmentName}}
     </p>
     <div class='au-u-flex au-u-flex--spaced-large au-u-flex--center'>
-      {{#if @message}}
+      {{#if (this.or @message (has-block "message"))}}
         <p class={{if this.showPackages 'au-u-3-5@medium' 'au-u-4-5@medium'}}>
-          {{string-format @message}}
+          {{#if @message}}
+            {{string-format @message}}
+          {{else}}
+            {{yield to="message"}}
+          {{/if}}
         </p>
       {{/if}}
       <p class='au-u-flex au-u-flex--vertical-center'>

--- a/addon/components/environment-banner.js
+++ b/addon/components/environment-banner.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
+import { helper } from '@ember/component/helper';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { dependencySatisfies, macroCondition } from '@embroider/macros';
@@ -11,8 +12,13 @@ const InfoCircleIcon = macroCondition(
       .InfoCircleIcon
   : 'info-circle';
 
+const or = helper(function ([a, b]) {
+  return a || b;
+});
+
 export default class EnvironmentBannerComponent extends Component {
   InfoCircleIcon = InfoCircleIcon;
+  or = or;
 
   @tracked
   showModal = false;


### PR DESCRIPTION
This has the benefit that the user can use components, instead of simply a html string.

For example, contactgegevens-loket uses this addon and provides a html string: https://github.com/lblod/frontend-contactgegevens-loket/blob/e18fefaf515792e8b3294b960f1d550841f4c343/app/templates/application.hbs#L13

It works, but the link isn't styled properly for example. We could add the `au-c-link` class, but using the AuLinkExternal component would be better.

Open questions:
- Should we deprecate the `@message` argument? With the block version there is no real benefit to use it I think?