### PR TITLE
Use a more specific includePaths config

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,9 +8,7 @@ module.exports = function (defaults) {
       disableWormholeElement: true,
     },
     sassOptions: {
-      // The docs say "node_modules/@appuniversum/ember-appuniversum" should work, but it fails for
-      // some reason...
-      includePaths: ['node_modules'],
+      includePaths: ['node_modules/@appuniversum'],
     },
     // Add options here
   });

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,3 +1,3 @@
 
 // EMBER-APPUNIVERSUM
-@import "@appuniversum/ember-appuniversum/styles";
+@import "ember-appuniversum/styles";


### PR DESCRIPTION
This speeds up the test app rebuilds considerably. Before this change the test app took 9 seconds to rebuild on my machine, due to the sass compiler.