### PR TITLE
Add support for ember-source v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.0.0 || ^3.0.0",
-        "ember-source": "^4.0.0"
+        "ember-source": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.0.0 || ^3.0.0",
-    "ember-source": "^4.0.0"
+    "ember-source": "^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
Some apps are on v5 already, and npm complains about the ember-source version sometimes.